### PR TITLE
➕(Dockerfile) install tar package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM java:7-jre-alpine
 
-RUN apk --no-cache add curl unzip
+RUN apk update && \
+    apk --no-cache add \
+      curl  \
+      tar   \
+      unzip
 
 RUN curl -o crowdin-cli.zip -SL https://downloads.crowdin.com/cli/v2/crowdin-cli.zip  && \
     unzip -j crowdin-cli.zip   && \


### PR DESCRIPTION
## Puporse

Circle-ci needs tar command to attach a workspace. Without this command
it is not possible to upload new translations on crowdin.

## Proposal

- [x] install tar in Dockerfile