### PR TITLE
🐳(Dockerfile) upgrade base image to java 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jre-alpine
+FROM java:8-jre-alpine
 
 RUN apk update && \
     apk --no-cache add \


### PR DESCRIPTION
## Purpose

The base image java 7 was not working anymore. There was a SSL error,
upgrading to java 8 resolved the issue, we don't have error anymore.

## Proposal

- [x] upgrade base image to java 8